### PR TITLE
Add WhatsApp form and subtitle

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,16 @@
 import pandas as pd
 import streamlit as st
+import streamlit.components.v1 as components
 
 st.title("Compare Lists")
+st.subheader("Yo se que todavia piensas en mi, si no porque estas aqui?")
+
+with st.form("whatsapp_form"):
+    st.write("Send a WhatsApp message to +1 786 553 5043")
+    submitted = st.form_submit_button("Send Helloooo")
+    if submitted:
+        url = "https://wa.me/17865535043?text=Helloooo"
+        components.html(f"<script>window.open('{url}');</script>")
 
 uploaded = st.file_uploader(
     "Upload one or more CSVs",


### PR DESCRIPTION
## Summary
- Add subtitle beneath main title.
- Include form to send pre-filled WhatsApp message to +1 786 553 5043.

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68be7c6b8f88833189c0a1b38e732575